### PR TITLE
Add IRIs fields to various document types

### DIFF
--- a/schemas/documents/registry/creditClass.js
+++ b/schemas/documents/registry/creditClass.js
@@ -1,3 +1,6 @@
+import slugifyToIRI from "../../../utils/slugifyToIRI";
+import toPlainText from "../../../utils/toPlainText";
+
 export default {
   type: 'document',
   name: 'creditClass',
@@ -8,6 +11,19 @@ export default {
       name: 'name',
       type: 'customPortableText',
       validation: Rule => Rule.required(),
+    },
+    {
+      title: 'IRI',
+      name: 'iri',
+      description: 'This can be generated based on the name',
+      type: 'slug',
+      validation: Rule => Rule.required(),
+      options: {
+        source: 'name',
+        slugify: (input) => {
+          return `${slugifyToIRI(toPlainText(input))}CreditClass`;
+        }
+      },
     },
     {
       title: 'Path',

--- a/schemas/documents/shared/ecologicalImpact.js
+++ b/schemas/documents/shared/ecologicalImpact.js
@@ -1,8 +1,23 @@
+import slugifyToIRI from "../../../utils/slugifyToIRI";
+
 export default {
   title: 'Ecological Impact',
   name: 'ecologicalImpact',
   type: 'document',
   fields: [
+    {
+      title: 'IRI',
+      name: 'iri',
+      type: 'slug',
+      hidden: true,
+      validation: Rule => Rule.required(),
+      options: {
+        source: 'name',
+        slugify: (input) => {
+          return slugifyToIRI(input);
+        }
+      },
+    },
     {
       title: 'Name',
       name: 'name',

--- a/schemas/documents/shared/ecologicalImpact.js
+++ b/schemas/documents/shared/ecologicalImpact.js
@@ -6,10 +6,16 @@ export default {
   type: 'document',
   fields: [
     {
+      title: 'Name',
+      name: 'name',
+      type: 'string',
+      validation: Rule => Rule.required(),
+    },
+    {
       title: 'IRI',
       name: 'iri',
+      description: 'This can be generated based on the name',
       type: 'slug',
-      hidden: true,
       validation: Rule => Rule.required(),
       options: {
         source: 'name',
@@ -17,12 +23,6 @@ export default {
           return slugifyToIRI(input);
         }
       },
-    },
-    {
-      title: 'Name',
-      name: 'name',
-      type: 'string',
-      validation: Rule => Rule.required(),
     },
     {
       title: 'Description',
@@ -35,6 +35,11 @@ export default {
       name: 'image',
       type: 'customImage',
       validation: Rule => Rule.required(),
+    },
+    {
+      title: 'Standard',
+      name: 'standard',
+      type: 'customImage',
     },
   ]
 }

--- a/schemas/documents/shared/resource.js
+++ b/schemas/documents/shared/resource.js
@@ -1,3 +1,5 @@
+import toPlainText from "../../../utils/toPlainText";
+
 export default {
   name: 'resource',
   type: 'document',
@@ -46,21 +48,3 @@ export default {
     }
   }
 }
-
-function toPlainText(blocks = []) {
-  return blocks
-    // loop through each block
-    .map(block => {
-      // if it's not a text block with children, 
-      // return nothing
-      if (block._type !== 'block' || !block.children) {
-        return ''
-      }
-      // loop through the children spans, and join the
-      // text strings
-      return block.children.map(child => child.text).join('')
-    })
-    // join the paragraphs leaving split by two linebreaks
-    .join('\n\n')
-}
-

--- a/schemas/documents/shared/sdg.js
+++ b/schemas/documents/shared/sdg.js
@@ -6,10 +6,16 @@ export default {
   type: 'document',
   fields: [
     {
+      title: 'Title',
+      name: 'title',
+      type: 'string',
+      validation: Rule => Rule.required(),
+    },
+     {
       title: 'IRI',
       name: 'iri',
+      description: 'This can be generated based on the title',
       type: 'slug',
-      hidden: true,
       validation: Rule => Rule.required(),
       options: {
         source: 'title',
@@ -17,12 +23,6 @@ export default {
           return slugifyToIRI(input);
         }
       },
-    },
-    {
-      title: 'Title',
-      name: 'title',
-      type: 'string',
-      validation: Rule => Rule.required(),
     },
     {
       title: 'Image',

--- a/schemas/documents/shared/sdg.js
+++ b/schemas/documents/shared/sdg.js
@@ -1,8 +1,23 @@
+import slugifyToIRI from "../../../utils/slugifyToIRI";
+
 export default {
   title: 'SDG',
   name: 'sdg',
   type: 'document',
   fields: [
+    {
+      title: 'IRI',
+      name: 'iri',
+      type: 'slug',
+      hidden: true,
+      validation: Rule => Rule.required(),
+      options: {
+        source: 'title',
+        slugify: (input) => {
+          return slugifyToIRI(input);
+        }
+      },
+    },
     {
       title: 'Title',
       name: 'title',

--- a/utils/isColor.js
+++ b/utils/isColor.js
@@ -1,3 +1,3 @@
-export default function isColor(strColor){
-    return CSS.supports('color', strColor)
+export default function isColor(strColor) {
+    return CSS.supports('color', strColor);
 }

--- a/utils/slugifyToIRI.js
+++ b/utils/slugifyToIRI.js
@@ -1,0 +1,3 @@
+export default function slugifyToIRI(input){
+    return `http://regen.network/${input.replace(/(?:^|\s)\S/g, (a) => a.toUpperCase()).replace(/\s+/g, '')}`;
+}

--- a/utils/toPlainText.js
+++ b/utils/toPlainText.js
@@ -1,0 +1,16 @@
+export default function toPlainText(blocks = []) {
+  return blocks
+    // loop through each block
+    .map(block => {
+      // if it's not a text block with children, 
+      // return nothing
+      if (block._type !== 'block' || !block.children) {
+        return ''
+      }
+      // loop through the children spans, and join the
+      // text strings
+      return block.children.map(child => child.text).join('')
+    })
+    // join the paragraphs leaving split by two linebreaks
+    .join('\n\n')
+}


### PR DESCRIPTION
## Description

ref: regen-network/regen-registry#84

Adds auto-generatable IRIs fields (using sanity slug type) to EcologicalImpact, SDG and CreditClass so that we can reference those IRIs in the db and have a central place (ie sanity) for editing their static content.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] added new items content to `./deskStructure.js` (not applicable)
- [ ] go through ["Deploying to production" instructions](../../README.md#deploying-to-production) after this PR (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)