### PR TITLE
extend validation of block content to allow mailto links

### DIFF
--- a/schemas/documents/registry/homePage.js
+++ b/schemas/documents/registry/homePage.js
@@ -2,7 +2,7 @@ export default {
   name: 'homePage',
   type: 'document',
   title: 'Home Page',
-  __experimental_actions: ['update', 'create', /*'delete', */ 'publish'],
+  __experimental_actions: ['update', /*'create', 'delete', */ 'publish'],
   fields: [
     {
       name: 'heroSection',

--- a/schemas/documents/www/homePageWeb.js
+++ b/schemas/documents/www/homePageWeb.js
@@ -2,7 +2,7 @@ export default {
   name: 'homePageWeb',
   type: 'document',
   title: 'Web Home Page',
-  __experimental_actions: ['update', 'create', 'delete', 'publish'],
+  __experimental_actions: ['update', /*'create', 'delete', */ 'publish'],
   fields: [
     {
       name: 'homeFoldSection',

--- a/schemas/objects/customPortableText.js
+++ b/schemas/objects/customPortableText.js
@@ -16,6 +16,10 @@ export default {
                 name: 'href',
                 type: 'url',
                 title: 'URL',
+                validation: Rule =>
+                  Rule.uri({
+                    scheme: ['http', 'https', 'mailto', 'tel'],
+                  }),
               },
               {
                 title: 'Open in new tab',


### PR DESCRIPTION
## Description

The previous version of sanity studio was allowing `mailto` links within custom block content, but apparently that wasn't expected behavior. 

This PR extends the normal block content schema to allow for other potential forms of links

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] added new items content to `./deskStructure.js`
- [ ] go through ["Deploying to production" instructions](https://github.com/regen-network/regen-sanity/blob/main/README.md#deploying-to-production) after this PR (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)