### PR TITLE
chore: remove contributor section from sanity

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@ Install dependencies using `yarn`.
 1. Run `yarn start` to start the studio locally.
 2. When adding new documents or objects to the schema, make sure to import them from `schemas/schemas.js`. In case of documents, you'll also need to make sure to add them to the appropriate list in `deskStructure` so it gets displayed on the Studio, whether it's as part under "Registry", "Website" or "Shared".
 
-### Formatting
-
-`yarn prettier` to format code
+**NOTE**: if changes have been made in the CMS since the last deploy, you should run `yarn import-production` to import the latest data before making changes locally
 
 ## Datasets and environments
 
 We have currently 2 [datasets](https://www.sanity.io/docs/datasets):
 
 - **staging**: used in development (both for running Sanity Studio locally and used to fetch Sanity content from the Registry app). It should be used for the Registry app deploy previews too after we merge https://github.com/regen-network/regen-web/pull/699 (this is configurable from https://github.com/regen-network/regen-web/blob/master/netlify.toml)
-- **production**: used in production from https://regen.sanity.studio/desk. Since we are using [built-in Sanity hosting solution](https://www.sanity.io/docs/deployment#bd4e07db3e37), we can only have one Studio available. But later on, we might want to use Netlify for hosting, which would allow us to have deploy previews for the Studio itself as well. In the mean time, we could use the [Spaces](https://www.sanity.io/docs/spaces) experimental feature to switch between datasets in the Studio.
+- **production**: used in production from https://regen.sanity.studio/desk. Since we are using [built-in Sanity hosting solution](https://www.sanity.io/docs/deployment#bd4e07db3e37), we can only have one Studio available. Once we [update to V3](https://www.sanity.io/blog/sanity-studio-v3-developer-preview), we might want to host our own solution to have deploy previews for the studio itself as well. In the mean time, we could use the [Spaces](https://www.sanity.io/docs/spaces) experimental feature to switch between datasets in the Studio.
 
-If content editors edited some content on the production dataset, you might want to update the staging dataset later on with these latest changes using:
+## Deploy Scripts
+
+- `yarn import-production` - pull production changes into the staging environment
+- `yarn deploy-staging` - deploy local changes to the staging GraphQL server and playground
 
 ```sh
 yarn import-production
@@ -35,10 +36,13 @@ yarn import-production
 When updating the schema in development, we might need to deploy this new schema to the GraphQL API regularly in order to use this updated version when fetching content from the Registry app or the website locally:
 
 ```sh
-yarn deploy-graphql
+yarn deploy-staging
 ```
 
 The GraphQL playground for staging dataset is available from https://jm12rn9t.api.sanity.io/v1/graphql/staging/default
+There's another playground for production dataset at https://jm12rn9t.api.sanity.io/v1/graphql/production/default
+
+These can be used for querying, but not mutations (see sanity's [docs](https://www.sanity.io/docs/migrating-data) on migrations)
 
 ### Deploying to production
 
@@ -47,7 +51,7 @@ When merging a PR, we have a Github workflow defined to deploy the latest change
 After merging a PR into the `main` branch, make sure to run:
 
 ```sh
-yarn deploy
+yarn deploy-production
 ```
 
 This will update the production GraphQL API with latest schema, export the staging dataset and import it into the production dataset, so that data that you've added while in development on the staging dataset can be automatically copied into the production dataset without the need to do it manually. Later on, we can add that to Github workflows too so that it's all handled by CI.

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "start": "sanity start",
     "build": "sanity build",
     "prettier": "prettier --write '**/*.js'",
-    "deploy-graphql": "sanity graphql deploy --playground",
-    "deploy": "sanity graphql deploy --playground --dataset production && sanity dataset export staging staging.tar.gz && sanity dataset import staging.tar.gz production --replace && rm staging.tar.gz",
+    "deploy-staging": "sanity graphql deploy --playground --dataset staging",
+    "deploy-production": "sanity graphql deploy --playground --dataset production && sanity dataset export staging staging.tar.gz && sanity dataset import staging.tar.gz production --replace && rm staging.tar.gz",
     "import-production": "sanity dataset export production production.tar.gz && sanity dataset import production.tar.gz staging --replace && rm production.tar.gz"
   },
   "keywords": [

--- a/schemas/documents/www/teamPage.js
+++ b/schemas/documents/www/teamPage.js
@@ -16,14 +16,8 @@ export default {
       validation: Rule => Rule.required(),
     },
     {
-      title: 'Contributor Section',
-      name: 'contributorSection',
-      type: 'teamSection',
-      validation: Rule => Rule.required(),
-    },
-    {
-      title: 'Advisor Section',
-      name: 'advisorSection',
+      title: 'Board Section',
+      name: 'advisorSection', // this was renamed on the site, but easier to keep as is
       type: 'teamSection',
       validation: Rule => Rule.required(),
     },

--- a/schemas/objects/sections/regenTeamMember.js
+++ b/schemas/objects/sections/regenTeamMember.js
@@ -16,12 +16,6 @@ export default {
       validation: Rule => Rule.required(),
     },
     {
-      title: 'Description',
-      name: 'description',
-      type: 'text',
-      validation: Rule => Rule.required(),
-    },
-    {
       title: 'Image',
       name: 'image',
       type: 'image',


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1033
Closes: regen-network/regen-registry#843
Closes: regen-network/regen-registry#1017

The UI has already been changed, but also needed to remove those sections in sanity 

regen-network/regen-registry#1064 should be merged after

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] added new items content to `./deskStructure.js`
- [ ] go through ["Deploying to production" instructions](https://github.com/regen-network/regen-sanity/blob/main/README.md#deploying-to-production) after this PR (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)