### PR TITLE
feat: add sold out projects list

### DIFF
--- a/deskStructure.js
+++ b/deskStructure.js
@@ -233,6 +233,10 @@ export default () => {
                     'Resource for Getting Started Cards',
                   ),
                 ),
+              S.listItem()
+                .title('Sold out projects')
+                .schemaType('soldOutProjects')
+                .child(S.documentTypeList('soldOutProjects').title('Sold out projects')),
             ]),
         ),
     ]);

--- a/schemas/documents/shared/soldOutProjects.js
+++ b/schemas/documents/shared/soldOutProjects.js
@@ -1,0 +1,18 @@
+export default {
+  title: 'Sold out projects',
+  name: 'soldOutProjects',
+  type: 'document',
+  __experimental_actions: ['update', 'create', /*'delete', */ 'publish'],
+  fields: [
+    {
+      title: 'Sold out projects list',
+      name: 'soldOutProjectsList',
+      type: 'array',
+      of: [
+        {
+          type: 'project',
+        },
+      ],
+    },
+  ],
+};

--- a/schemas/documents/shared/soldOutProjects.js
+++ b/schemas/documents/shared/soldOutProjects.js
@@ -2,7 +2,6 @@ export default {
   title: 'Sold out projects',
   name: 'soldOutProjects',
   type: 'document',
-  __experimental_actions: ['update', 'create', /*'delete', */ 'publish'],
   fields: [
     {
       title: 'Sold out projects list',

--- a/schemas/objects/project.js
+++ b/schemas/objects/project.js
@@ -4,12 +4,13 @@ export default {
   title: 'Project',
   fields: [
     {
+      // optionnal project name to make it easier to track projects already added to the list
       title: 'Project name',
       name: 'projectName',
       type: 'string',
-      validation: Rule => Rule.required(),
     },
     {
+      // on-chain project id
       title: 'Project id',
       name: 'projectId',
       type: 'string',

--- a/schemas/objects/project.js
+++ b/schemas/objects/project.js
@@ -1,0 +1,19 @@
+export default {
+  type: 'object',
+  name: 'project',
+  title: 'Project',
+  fields: [
+    {
+      title: 'Project name',
+      name: 'projectName',
+      type: 'string',
+      validation: Rule => Rule.required(),
+    },
+    {
+      title: 'Project id',
+      name: 'projectId',
+      type: 'string',
+      validation: Rule => Rule.required(),
+    },
+  ],
+};

--- a/schemas/objects/project.js
+++ b/schemas/objects/project.js
@@ -4,16 +4,17 @@ export default {
   title: 'Project',
   fields: [
     {
-      // optionnal project name to make it easier to track projects already added to the list
       title: 'Project name',
       name: 'projectName',
       type: 'string',
+      description:
+        'optional project name to make it easier to track projects already added to the list',
     },
     {
-      // on-chain project id
       title: 'Project id',
       name: 'projectId',
       type: 'string',
+      description: 'on-chain project id',
       validation: Rule => Rule.required(),
     },
   ],

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -33,6 +33,7 @@ import tag from './documents/shared/tag';
 import featuredSection from './documents/shared/featuredSection';
 import gettingStartedResourcesSection from './documents/shared/gettingStartedResourcesSection';
 import gettingStartedResourcesCard from './documents/shared/gettingStartedResourcesCard';
+import soldOutProjects from './documents/shared/soldOutProjects';
 
 // Object types
 import heroSection from './objects/sections/heroSection';
@@ -126,6 +127,7 @@ import titleImageLink from './objects/templates/titleImageLink';
 import presskitTimelineItem from './objects/presskitTimelineItem';
 import presskitTimelineSection from './objects/sections/presskit/presskitTimelineSection';
 import presskitTeamSection from './objects/sections/presskit/presskitTeamSection';
+import project from './objects/project';
 import nameTitleImage from './objects/templates/nameTitleImage';
 import presskitLogosSection from './objects/sections/presskit/presskitLogosSection';
 import presskitPhotosSection from './objects/sections/presskit/presskitPhotosSection';
@@ -281,6 +283,7 @@ export default createSchema({
     presskitTeamSection,
     presskitTimelineItem,
     presskitTimelineSection,
+    project,
     projectPage,
     projectsPage,
     regenTeamMember,
@@ -301,6 +304,7 @@ export default createSchema({
     sdg,
     seo,
     sharedSections,
+    soldOutProjects,
     stepCard,
     stepCardSection,
     tag,


### PR DESCRIPTION
## Description

Closes: #1518

- add project object
- `soldOutProjects`list to flag some projects as being "sold out" and be able to display them differently in the marketplace

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] added new items content to `./deskStructure.js`
- [ ] go through ["Deploying to production" instructions](https://github.com/regen-network/regen-sanity/blob/main/README.md#deploying-to-production) after this PR (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)