### PR TITLE
feat: add project details section schemas

### DIFF
--- a/deskStructure.js
+++ b/deskStructure.js
@@ -269,6 +269,14 @@ export default S =>
                 .title('Stat Card')
                 .schemaType('statCard')
                 .child(S.documentTypeList('statCard').title('Stat Card')),
+              S.listItem()
+                .title('Claim')
+                .schemaType('claim')
+                .child(S.documentTypeList('claim').title('Claim')),
+              S.listItem()
+                .title('Credibility Card')
+                .schemaType('credibilityCard')
+                .child(S.documentTypeList('credibilityCard').title('Credibility Card')),
             ]),
         ),
     ]);

--- a/schemas/documents/registry/projectPage.js
+++ b/schemas/documents/registry/projectPage.js
@@ -11,5 +11,11 @@ export default {
       title: 'Resources for Getting Started Section',
       validation: Rule => Rule.required(),
     },
+    {
+      name: 'projectDetailsSection',
+      type: 'projectDetailsSection',
+      title: 'Project Details Section',
+      validation: Rule => Rule.required(),
+    },
   ],
 };

--- a/schemas/documents/shared/claim.js
+++ b/schemas/documents/shared/claim.js
@@ -9,10 +9,5 @@ export default {
       type: 'string',
       validation: Rule => Rule.required(),
     },
-    {
-      title: 'Third Party Verified',
-      name: 'thirdPartyVerified',
-      type: 'boolean',
-    },
   ],
 };

--- a/schemas/documents/shared/claim.js
+++ b/schemas/documents/shared/claim.js
@@ -1,0 +1,18 @@
+export default {
+  title: 'Claim',
+  name: 'claim',
+  type: 'document',
+  fields: [
+    {
+      title: 'Description',
+      name: 'description',
+      type: 'string',
+      validation: Rule => Rule.required(),
+    },
+    {
+      title: 'Third Party Verified',
+      name: 'thirdPartyVerified',
+      type: 'boolean',
+    },
+  ],
+};

--- a/schemas/documents/shared/credibilityCard.js
+++ b/schemas/documents/shared/credibilityCard.js
@@ -1,0 +1,36 @@
+export default {
+  title: 'Credibility Card',
+  name: 'credibilityCard',
+  type: 'document',
+  fields: [
+    {
+      title: 'Title',
+      name: 'title',
+      type: 'string',
+      validation: Rule => Rule.required(),
+    },
+    {
+      title: 'Description',
+      name: 'description',
+      type: 'customPortableText',
+      validation: Rule => Rule.required(),
+    },
+    {
+      title: 'Icon',
+      name: 'icon',
+      type: 'image',
+    },
+    {
+      title: 'Claims',
+      name: 'claims',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{ type: 'claim' }],
+        },
+      ],
+      validation: Rule => Rule.required(),
+    },
+  ],
+};

--- a/schemas/documents/shared/credibilityCard.js
+++ b/schemas/documents/shared/credibilityCard.js
@@ -20,17 +20,5 @@ export default {
       name: 'icon',
       type: 'image',
     },
-    {
-      title: 'Claims',
-      name: 'claims',
-      type: 'array',
-      of: [
-        {
-          type: 'reference',
-          to: [{ type: 'claim' }],
-        },
-      ],
-      validation: Rule => Rule.required(),
-    },
   ],
 };

--- a/schemas/documents/shared/project.js
+++ b/schemas/documents/shared/project.js
@@ -23,8 +23,7 @@ export default {
       type: 'array',
       of: [
         {
-          type: 'reference',
-          to: [{ type: 'credibilityCard' }],
+          type: 'projectDetailsCard',
         },
       ],
       validation: Rule => Rule.required(),

--- a/schemas/documents/shared/project.js
+++ b/schemas/documents/shared/project.js
@@ -17,5 +17,17 @@ export default {
       description: 'on-chain project id',
       validation: Rule => Rule.required(),
     },
+    {
+      title: 'Credibility Cards',
+      name: 'credibilityCards',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{ type: 'credibilityCard' }],
+        },
+      ],
+      validation: Rule => Rule.required(),
+    },
   ],
 };

--- a/schemas/objects/sections/projectPage/projectDetails.js
+++ b/schemas/objects/sections/projectPage/projectDetails.js
@@ -1,0 +1,25 @@
+export default {
+  type: 'object',
+  title: 'Project Details Section',
+  name: 'projectDetailsSection',
+  fields: [
+    {
+      title: 'Label',
+      name: 'label',
+      type: 'string',
+      validation: Rule => Rule.required(),
+    },
+    {
+      title: 'Title',
+      name: 'title',
+      type: 'string',
+      validation: Rule => Rule.required(),
+    },
+    {
+      title: 'Description',
+      name: 'description',
+      type: 'customPortableText',
+      validation: Rule => Rule.required(),
+    },
+  ],
+};

--- a/schemas/objects/sections/projectPage/projectDetailsCard.js
+++ b/schemas/objects/sections/projectPage/projectDetailsCard.js
@@ -1,0 +1,26 @@
+export default {
+  type: 'object',
+  title: 'Project Details Card',
+  name: 'projectDetailsCard',
+  fields: [
+    {
+      title: 'Credibility Card',
+      name: 'credibilityCard',
+      type: 'reference',
+      to: [{ type: 'credibilityCard' }],
+      validation: Rule => Rule.required(),
+    },
+    {
+      title: 'Claims',
+      name: 'claims',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{ type: 'claim' }],
+        },
+      ],
+      validation: Rule => Rule.required(),
+    },
+  ],
+};

--- a/schemas/objects/sections/projectPage/projectDetailsCard.js
+++ b/schemas/objects/sections/projectPage/projectDetailsCard.js
@@ -23,4 +23,21 @@ export default {
       validation: Rule => Rule.required(),
     },
   ],
+  preview: {
+    select: {
+      credibilityCardTitle: 'credibilityCard.title',
+      claim0: 'claims.0.description',
+      claim1: 'claims.1.description',
+      claim2: 'claims.2.description',
+    },
+    prepare(selection) {
+      const { credibilityCardTitle, claim0, claim1, claim2 } = selection;
+      const claims = [claim0, claim1, claim2].filter(Boolean);
+
+      return {
+        title: credibilityCardTitle,
+        subtitle: claims.join(', '),
+      };
+    },
+  },
 };

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -38,6 +38,8 @@ import project from './documents/shared/project';
 import featuredProjectCard from './documents/shared/featuredProjectCard';
 import partner from './documents/shared/partner';
 import statCard from './documents/shared/statCard';
+import claim from './documents/shared/claim';
+import credibilityCard from './documents/shared/credibilityCard';
 
 // Object types
 import heroSection from './objects/sections/heroSection';
@@ -53,6 +55,7 @@ import dualImageSection from './objects/sections/dualImageSection';
 import practicesOutcomesSection from './objects/sections/practicesOutcomesSection';
 import timelineSection from './objects/sections/timelineSection';
 import imageGridSection from './objects/sections/imageGridSection';
+import projectDetails from './objects/sections/projectPage/projectDetails';
 
 import stepCard from './objects/stepCard';
 import bottomBanner from './objects/bottomBanner';
@@ -214,7 +217,9 @@ export default [
   caseStudyFigureSection,
   caseStudyFundingSection,
   caseStudyPage,
+  claim,
   climateSection,
+  credibilityCard,
   communityCollaborateSection,
   communityCollectiveSection,
   communityConnectSection,
@@ -307,6 +312,7 @@ export default [
   presskitTimelineSection,
   project,
   projectActivity,
+  projectDetails,
   projectPage,
   projectsPage,
   regenTeamMember,

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -56,6 +56,7 @@ import practicesOutcomesSection from './objects/sections/practicesOutcomesSectio
 import timelineSection from './objects/sections/timelineSection';
 import imageGridSection from './objects/sections/imageGridSection';
 import projectDetails from './objects/sections/projectPage/projectDetails';
+import projectDetailsCard from './objects/sections/projectPage/projectDetailsCard';
 
 import stepCard from './objects/stepCard';
 import bottomBanner from './objects/bottomBanner';
@@ -313,6 +314,7 @@ export default [
   project,
   projectActivity,
   projectDetails,
+  projectDetailsCard,
   projectPage,
   projectsPage,
   regenTeamMember,


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1650

new documents:
- `claim` in `shared`
- `credibilityCard` in `shared`

new object:
- `projectDetailsSection`
- `projectDetailsCard` (uses credibilityCard and claims)

updated documents:
- `projectPage` (uses `projectDetailsSection`)
- `project` (uses an array `projectDetailsCard`)

All changes have been deployed to staging.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] added new items content to `./deskStructure.js`
- [ ] go through ["Deploying to production" instructions](https://github.com/regen-network/regen-sanity/blob/main/README.md#deploying-to-production) after this PR (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)