### PR TITLE
feat: add regen marketplace image

### DIFF
--- a/schemas/documents/www/homePageWeb.js
+++ b/schemas/documents/www/homePageWeb.js
@@ -10,6 +10,12 @@ export default {
       validation: Rule => Rule.required(),
     },
     {
+      name: 'carbonPlusSection',
+      type: 'carbonPlusSection',
+      title: 'Carbon Plus Section',
+      validation: Rule => Rule.required(),
+    },
+    {
       name: 'marketplaceSection',
       type: 'marketplaceSection',
       title: 'Marketplace Section',
@@ -43,12 +49,6 @@ export default {
       name: 'climateSection',
       type: 'climateSection',
       title: 'Climate Section',
-      validation: Rule => Rule.required(),
-    },
-    {
-      name: 'carbonPlusSection',
-      type: 'carbonPlusSection',
-      title: 'Carbon Plus Section',
       validation: Rule => Rule.required(),
     },
     {

--- a/schemas/objects/sections/homePageWeb/carbonPlusSection.js
+++ b/schemas/objects/sections/homePageWeb/carbonPlusSection.js
@@ -39,5 +39,11 @@ export default {
       type: 'string',
       validation: Rule => Rule.required(),
     },
+    {
+      title: 'Image',
+      name: 'image',
+      type: 'customImage',
+      validation: Rule => Rule.required(),
+    },
   ],
 };


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#1844

- Add an image field to `carbonPlus` section
- Move `carbonPlus` to second position in sanity studio to reflect page ordering

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] added new items content to `./deskStructure.js`
- [ ] go through ["Deploying to production" instructions](https://github.com/regen-network/regen-sanity/blob/main/README.md#deploying-to-production) after this PR (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)