### PR TITLE
feat: buyers page optional data

### DIFF
--- a/schemas/documents/shared/ecologicalCreditCard.js
+++ b/schemas/documents/shared/ecologicalCreditCard.js
@@ -50,7 +50,6 @@ export default {
           to: [{ type: 'offsetMethod' }],
         },
       ],
-      validation: Rule => Rule.required().min(1),
     },
     {
       title: 'Project Activities',

--- a/schemas/documents/shared/ecologicalCreditCard.js
+++ b/schemas/documents/shared/ecologicalCreditCard.js
@@ -67,5 +67,10 @@ export default {
       name: 'button',
       type: 'button',
     },
+    {
+      title: 'Secondary Button',
+      name: 'secondaryButton',
+      type: 'button',
+    },
   ],
 };


### PR DESCRIPTION
## Description

Part of: regen-network/rnd-dev-team#1829

- make offset generation methods optional for ecological cards
- add a secondary button to ecological cards

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] added new items content to `./deskStructure.js`
- [ ] go through ["Deploying to production" instructions](https://github.com/regen-network/regen-sanity/blob/main/README.md#deploying-to-production) after this PR (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)