### PR TITLE
fix: custom unique slug excluding documents of same language 

### DIFF
--- a/schemas/documents/registry/creditClass.js
+++ b/schemas/documents/registry/creditClass.js
@@ -1,4 +1,5 @@
 import slugifyToIRI from '../../../utils/slugifyToIRI';
+import isUniqueSlug from '../../../utils/isUniqueSlug';
 import toPlainText from '../../../utils/toPlainText';
 
 export default {
@@ -20,6 +21,7 @@ export default {
       validation: Rule => Rule.required(),
       options: {
         source: 'name',
+        isUnique: isUniqueSlug,
         slugify: input => {
           return `${slugifyToIRI(toPlainText(input))}CreditClass`;
         },

--- a/schemas/documents/shared/ecologicalImpact.js
+++ b/schemas/documents/shared/ecologicalImpact.js
@@ -1,4 +1,5 @@
 import slugifyToIRI from '../../../utils/slugifyToIRI';
+import isUniqueSlug from '../../../utils/isUniqueSlug';
 
 export default {
   title: 'Ecological Impact',
@@ -19,6 +20,7 @@ export default {
       validation: Rule => Rule.required(),
       options: {
         source: 'name',
+        isUnique: isUniqueSlug,
         slugify: input => {
           return slugifyToIRI(input);
         },

--- a/schemas/documents/shared/sdg.js
+++ b/schemas/documents/shared/sdg.js
@@ -1,4 +1,5 @@
 import slugifyToIRI from '../../../utils/slugifyToIRI';
+import isUniqueSlug from '../../../utils/isUniqueSlug';
 
 export default {
   title: 'SDG',
@@ -19,6 +20,7 @@ export default {
       validation: Rule => Rule.required(),
       options: {
         source: 'title',
+        isUnique: isUniqueSlug,
         slugify: input => {
           return slugifyToIRI(input);
         },

--- a/utils/isUniqueSlug.js
+++ b/utils/isUniqueSlug.js
@@ -1,0 +1,21 @@
+// Custom unique function for iri slugs that only checks the documents of the same type and the same language
+export default function isUniqueSlug(slug, context) {
+  const { document, getClient } = context
+  const docType = document._type;
+  const language = document.language || 'en';
+
+  const query = `
+    *[_type == $docType && language == $language && iri.current == $iri && _id != $id][0]
+  `;
+
+  const params = {
+    docType,
+    language,
+    iri: slug,
+    id: document._id,
+  };
+
+  return getClient({ apiVersion: '2023-01-01' })
+    .fetch(query, params)
+    .then((result) => !result);
+}


### PR DESCRIPTION
## Description

Ability to have documents with the same iri/slug as long as they have a different language.
Fixing this type of issue when creating en/es versions of a document with some iri:

<img width="1502" alt="image" src="https://github.com/user-attachments/assets/699c9b04-e0e7-4090-bed7-a3d0da70b1d7">


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] added new items content to `./deskStructure.js`
- [ ] go through ["Deploying to production" instructions](https://github.com/regen-network/regen-sanity/blob/main/README.md#deploying-to-production) after this PR (and other PRs depending on this one, e.g. on regen-network/regen-web, if applicable) get merged

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)